### PR TITLE
Rename getXxx methods to getOrCreateXxx

### DIFF
--- a/src/main/java/com/dsingley/testpki/TestPKI.java
+++ b/src/main/java/com/dsingley/testpki/TestPKI.java
@@ -57,15 +57,15 @@ public class TestPKI {
         CommandLineOptions commandLineOptions = CommandLineOptions.parse(args);
         TestPKI testPKI = new TestPKI(commandLineOptions.getKeyType());
 
-        File truststoreFile = testPKI.getTruststoreFile(commandLineOptions.getBaseDirectory());
-        File caPemFile = testPKI.getCaPemFile(commandLineOptions.getBaseDirectory());
+        File truststoreFile = testPKI.getOrCreateTruststoreFile(commandLineOptions.getBaseDirectory());
+        File caPemFile = testPKI.getOrCreateCaPemFile(commandLineOptions.getBaseDirectory());
 
-        TestPKICertificate serverCertificate = testPKI.getServerCertificate();
+        TestPKICertificate serverCertificate = testPKI.getOrCreateServerCertificate();
         File serverKeystoreFile = serverCertificate.getKeystoreFile(commandLineOptions.getBaseDirectory());
         File serverCertPemFile = serverCertificate.getCertPemFile(commandLineOptions.getBaseDirectory());
         File serverKeyPemFile = serverCertificate.getKeyPemFile(commandLineOptions.getBaseDirectory());
 
-        TestPKICertificate clientCertificate = testPKI.getClientCertificate();
+        TestPKICertificate clientCertificate = testPKI.getOrCreateClientCertificate();
         File clientKeystoreFile = clientCertificate.getKeystoreFile(commandLineOptions.getBaseDirectory());
         File clientCertPemFile = clientCertificate.getCertPemFile(commandLineOptions.getBaseDirectory());
         File clientKeyPemFile = clientCertificate.getKeyPemFile(commandLineOptions.getBaseDirectory());
@@ -123,8 +123,8 @@ public class TestPKI {
      *
      * @return the truststore file as a File object
      */
-    public File getTruststoreFile() {
-        return getTruststoreFile(null);
+    public File getOrCreateTruststoreFile() {
+        return getOrCreateTruststoreFile(null);
     }
 
     /**
@@ -135,7 +135,7 @@ public class TestPKI {
      * @return the truststore file as a File object
      */
     @Synchronized
-    public File getTruststoreFile(File baseDirectory) {
+    public File getOrCreateTruststoreFile(File baseDirectory) {
         if (truststoreFile != null) {
             return truststoreFile;
         }
@@ -145,7 +145,7 @@ public class TestPKI {
 
     /**
      * Retrieve the password for the truststore file accessible via
-     * {@link TestPKI#getTruststoreFile()} or {@link TestPKI#getTruststoreFile(File)}
+     * {@link TestPKI#getOrCreateTruststoreFile()} or {@link TestPKI#getOrCreateTruststoreFile(File)}
      *
      * @return the truststore password as a String
      */
@@ -159,8 +159,8 @@ public class TestPKI {
      *
      * @return the CA PEM file as a File object
      */
-    public File getCaPemFile() {
-        return getCaPemFile(null);
+    public File getOrCreateCaPemFile() {
+        return getOrCreateCaPemFile(null);
     }
 
     /**
@@ -171,7 +171,7 @@ public class TestPKI {
      * @return the CA PEM file as a File object
      */
     @Synchronized
-    public File getCaPemFile(File baseDirectory) {
+    public File getOrCreateCaPemFile(File baseDirectory) {
         if (caPemFile != null) {
             return caPemFile;
         }
@@ -186,12 +186,12 @@ public class TestPKI {
      * @return the default server certificate as a TestPKICertificate
      */
     @SneakyThrows
-    public TestPKICertificate getServerCertificate() {
+    public TestPKICertificate getOrCreateServerCertificate() {
         Set<String> subjectAlternativeNames = new TreeSet<>();
         subjectAlternativeNames.add("localhost");
         subjectAlternativeNames.add(InetAddress.getLocalHost().getHostName());
         subjectAlternativeNames.add(InetAddress.getLocalHost().getCanonicalHostName());
-        return getServerCertificate("server", subjectAlternativeNames);
+        return getOrCreateServerCertificate("server", subjectAlternativeNames);
     }
 
     /**
@@ -201,8 +201,8 @@ public class TestPKI {
      * @param commonName the desired common name
      * @return the server certificate as a TestPKICertificate
      */
-    public TestPKICertificate getServerCertificate(@NonNull String commonName) {
-        return getServerCertificate(commonName, Collections.emptySet());
+    public TestPKICertificate getOrCreateServerCertificate(@NonNull String commonName) {
+        return getOrCreateServerCertificate(commonName, Collections.emptySet());
     }
 
     /**
@@ -214,7 +214,7 @@ public class TestPKI {
      * @param subjectAlternativeNames the desired subject alternative names
      * @return the server certificate as a TestPKICertificate
      */
-    public TestPKICertificate getServerCertificate(@NonNull String commonName, @NonNull Set<String> subjectAlternativeNames) {
+    public TestPKICertificate getOrCreateServerCertificate(@NonNull String commonName, @NonNull Set<String> subjectAlternativeNames) {
         return issuedCertificates.computeIfAbsent(commonName, cn -> new TestPKICertificate(this, commonName, newCertificate(cn, subjectAlternativeNames)));
     }
 
@@ -224,8 +224,8 @@ public class TestPKI {
      *
      * @return the default client certificate as a TestPKICertificate
      */
-    public TestPKICertificate getClientCertificate() {
-        return getClientCertificate("client");
+    public TestPKICertificate getOrCreateClientCertificate() {
+        return getOrCreateClientCertificate("client");
     }
 
     /**
@@ -235,7 +235,7 @@ public class TestPKI {
      * @param commonName the desired common name
      * @return the client certificate as a TestPKICertificate
      */
-    public TestPKICertificate getClientCertificate(@NonNull String commonName) {
+    public TestPKICertificate getOrCreateClientCertificate(@NonNull String commonName) {
         return issuedCertificates.computeIfAbsent(commonName, cn -> new TestPKICertificate(this, commonName, newCertificate(cn, Collections.emptySet())));
     }
 

--- a/src/test/java/com/dsingley/testpki/TestPKICertificateTest.java
+++ b/src/test/java/com/dsingley/testpki/TestPKICertificateTest.java
@@ -10,7 +10,7 @@ class TestPKICertificateTest {
     @Test
     void test() {
         TestPKI testPKI = new TestPKI(KeyType.ECDSA_256);
-        TestPKICertificate certificate = testPKI.getServerCertificate();
+        TestPKICertificate certificate = testPKI.getOrCreateServerCertificate();
         assertAll(
                 () -> assertThat(certificate.getSubjectDN()).startsWith("CN=server"),
                 () -> assertThat(certificate.getSerialNumber()).isGreaterThan(1),

--- a/src/test/java/com/dsingley/testpki/TestPKITest.java
+++ b/src/test/java/com/dsingley/testpki/TestPKITest.java
@@ -37,8 +37,8 @@ class TestPKITest {
 
         @Test
         void testServerCertificateIdentity() {
-            TestPKICertificate certificate1 = testPKI.getServerCertificate();
-            TestPKICertificate certificate2 = testPKI.getServerCertificate();
+            TestPKICertificate certificate1 = testPKI.getOrCreateServerCertificate();
+            TestPKICertificate certificate2 = testPKI.getOrCreateServerCertificate();
             assertAll(
                     () -> assertThat(certificate1).isNotNull(),
                     () -> assertThat(certificate2).isNotNull(),
@@ -48,8 +48,8 @@ class TestPKITest {
 
         @Test
         void testClientCertificateIdentity() {
-            TestPKICertificate certificate1 = testPKI.getClientCertificate();
-            TestPKICertificate certificate2 = testPKI.getClientCertificate();
+            TestPKICertificate certificate1 = testPKI.getOrCreateClientCertificate();
+            TestPKICertificate certificate2 = testPKI.getOrCreateClientCertificate();
             assertAll(
                     () -> assertThat(certificate1).isNotNull(),
                     () -> assertThat(certificate2).isNotNull(),
@@ -59,7 +59,7 @@ class TestPKITest {
 
         @Test
         void testCustomServerCertificate() throws Exception {
-            TestPKICertificate certificate = testPKI.getServerCertificate("custom-server");
+            TestPKICertificate certificate = testPKI.getOrCreateServerCertificate("custom-server");
 
             KeyStore keyStore = loadKeyStore(certificate.getKeystoreFile(), certificate.getKeystorePassword());
             assertAll(
@@ -74,7 +74,7 @@ class TestPKITest {
         @Test
         void testCustomServerCertificateWithSANs() throws Exception {
             Set<String> subjectAlternativeNames = new HashSet<>(Arrays.asList("san-1", "san-2"));
-            TestPKICertificate testPKICertificate = testPKI.getServerCertificate("san-server", subjectAlternativeNames);
+            TestPKICertificate testPKICertificate = testPKI.getOrCreateServerCertificate("san-server", subjectAlternativeNames);
 
             KeyStore keyStore = loadKeyStore(testPKICertificate.getKeystoreFile(), testPKICertificate.getKeystorePassword());
             assertAll(
@@ -92,7 +92,7 @@ class TestPKITest {
 
         @Test
         void testCustomClientCertificate() throws Exception {
-            TestPKICertificate certificate = testPKI.getClientCertificate("custom-client");
+            TestPKICertificate certificate = testPKI.getOrCreateClientCertificate("custom-client");
 
             KeyStore keyStore = loadKeyStore(certificate.getKeystoreFile(), certificate.getKeystorePassword());
             assertAll(
@@ -107,7 +107,7 @@ class TestPKITest {
         @Test
         void testSSLSocketFactoriesAndTrustManager() throws Exception{
             try (MockWebServer mockWebServer = new MockWebServer()) {
-                mockWebServer.useHttps(testPKI.getServerCertificate().getSSLSocketFactory());
+                mockWebServer.useHttps(testPKI.getOrCreateServerCertificate().getSSLSocketFactory());
                 mockWebServer.requestClientAuth();
 
                 mockWebServer.enqueue(new MockResponse.Builder()
@@ -117,7 +117,7 @@ class TestPKITest {
                 );
 
                 OkHttpClient client = new OkHttpClient.Builder()
-                        .sslSocketFactory(testPKI.getClientCertificate().getSSLSocketFactory(), testPKI.getClientCertificate().getTrustManager())
+                        .sslSocketFactory(testPKI.getOrCreateClientCertificate().getSSLSocketFactory(), testPKI.getOrCreateClientCertificate().getTrustManager())
                         .dns(new IPv4OnlyDns())
                         .build();
 
@@ -147,7 +147,7 @@ class TestPKITest {
 
             @Test
             void testTruststoreFile() throws Exception {
-                File truststoreFile = testPKI.getTruststoreFile();
+                File truststoreFile = testPKI.getOrCreateTruststoreFile();
                 String truststorePassword = testPKI.getTruststorePassword();
                 assertAll(
                         () -> assertThat(truststoreFile.getAbsolutePath()).matches(".*/truststore.*\\.pkcs12"),
@@ -171,7 +171,7 @@ class TestPKITest {
 
             @Test
             void testCaPemFile() throws Exception {
-                File caPemFile = testPKI.getCaPemFile();
+                File caPemFile = testPKI.getOrCreateCaPemFile();
                 assertAll(
                         () -> assertThat(caPemFile.getAbsolutePath()).matches(".*/ca.*\\.pem"),
                         () -> assertThat(caPemFile).exists()
@@ -192,8 +192,8 @@ class TestPKITest {
 
             @Test
             void testKeystoreFile() throws Exception {
-                File keystoreFile = testPKI.getServerCertificate().getKeystoreFile();
-                String keystorePassword = testPKI.getServerCertificate().getKeystorePassword();
+                File keystoreFile = testPKI.getOrCreateServerCertificate().getKeystoreFile();
+                String keystorePassword = testPKI.getOrCreateServerCertificate().getKeystorePassword();
                 assertAll(
                         () -> assertThat(keystoreFile.getAbsolutePath()).matches(".*/server.*\\.pkcs12"),
                         () -> assertThat(keystoreFile).exists(),
@@ -215,7 +215,7 @@ class TestPKITest {
 
             @Test
             void testCertPemFile() throws Exception {
-                File certPemFile = testPKI.getServerCertificate().getCertPemFile();
+                File certPemFile = testPKI.getOrCreateServerCertificate().getCertPemFile();
                 assertAll(
                         () -> assertThat(certPemFile.getAbsolutePath()).matches(".*/server.*\\.cert"),
                         () -> assertThat(certPemFile).exists()
@@ -231,7 +231,7 @@ class TestPKITest {
 
             @Test
             void testKeyPemFile() throws Exception {
-                File keyPemFile = testPKI.getServerCertificate().getKeyPemFile();
+                File keyPemFile = testPKI.getOrCreateServerCertificate().getKeyPemFile();
                 assertAll(
                         () -> assertThat(keyPemFile.getAbsolutePath()).matches(".*/server.*\\.key"),
                         () -> assertThat(keyPemFile).exists()
@@ -251,8 +251,8 @@ class TestPKITest {
 
             @Test
             void testKeystoreFile() throws Exception {
-                File keystoreFile = testPKI.getClientCertificate().getKeystoreFile();
-                String keystorePassword = testPKI.getClientCertificate().getKeystorePassword();
+                File keystoreFile = testPKI.getOrCreateClientCertificate().getKeystoreFile();
+                String keystorePassword = testPKI.getOrCreateClientCertificate().getKeystorePassword();
                 assertAll(
                         () -> assertThat(keystoreFile.getAbsolutePath()).matches(".*/client.*\\.pkcs12"),
                         () -> assertThat(keystoreFile).exists(),
@@ -271,7 +271,7 @@ class TestPKITest {
 
             @Test
             void testCertPemFile() throws Exception {
-                File certPemFile = testPKI.getClientCertificate().getCertPemFile();
+                File certPemFile = testPKI.getOrCreateClientCertificate().getCertPemFile();
                 assertAll(
                         () -> assertThat(certPemFile.getAbsolutePath()).matches(".*/client.*\\.cert"),
                         () -> assertThat(certPemFile).exists()
@@ -287,7 +287,7 @@ class TestPKITest {
 
             @Test
             void testKeyPemFile() throws Exception {
-                File keyPemFile = testPKI.getClientCertificate().getKeyPemFile();
+                File keyPemFile = testPKI.getOrCreateClientCertificate().getKeyPemFile();
                 assertAll(
                         () -> assertThat(keyPemFile.getAbsolutePath()).matches(".*/client.*\\.key"),
                         () -> assertThat(keyPemFile).exists()


### PR DESCRIPTION
This makes it more clear that the getXxx methods may also have the side-effect of creating the Xxx, like a trust store. The Javadocs already state this, plus the fact that the created Xxx are tempoary.