### PR TITLE
initialize TestPKI with an optional base directory for all created files

### DIFF
--- a/src/main/java/com/dsingley/testpki/TestPKICertificate.java
+++ b/src/main/java/com/dsingley/testpki/TestPKICertificate.java
@@ -2,21 +2,20 @@ package com.dsingley.testpki;
 
 import lombok.Getter;
 import lombok.Synchronized;
-import org.checkerframework.checker.nullness.qual.Nullable;
 import okhttp3.tls.HeldCertificate;
 
-import javax.net.ssl.SSLSocketFactory;
-import javax.net.ssl.X509TrustManager;
 import java.io.File;
 import java.security.SecureRandom;
 import java.util.Base64;
 import java.util.Collections;
+import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.X509TrustManager;
 
 /**
  * A TestPKICertificate represents a certificated issued by a {@link TestPKI} instance.
  * <p>
- * It can create persistent or temporary PKCS12 keystore and/or PEM files containing
- * the issued certificate and access to the password for the PKCS12 keystore.
+ * It can create PKCS12 keystore and/or PEM files containing the issued certificate
+ * and access to the password for the PKCS12 keystore.
  * <p>
  * It can provide {@link SSLSocketFactory} and {@link X509TrustManager} instances to use
  * for TLS communication.
@@ -56,52 +55,31 @@ public class TestPKICertificate {
 
     /**
      * Get a reference to a keystore file containing the certificate, creating
-     * a temporary file on disk if not already created.
+     * the file on disk if not already created.
      *
-     * @return the keystore file as a File object
-     */
-    public File getKeystoreFile() {
-        return getKeystoreFile(null);
-    }
-
-    /**
-     * Get a reference to a keystore file containing the certificate, creating
-     * the file on disk in the specified directory if not already created.
-     *
-     * @param baseDirectory the directory in which to create the file, will create a temporary file if null
      * @return the keystore file as a File object
      */
     @Synchronized
-    public File getKeystoreFile(@Nullable File baseDirectory) {
+    public File getOrCreateKeystoreFile() {
         if (keystoreFile != null) {
             return keystoreFile;
         }
-        keystoreFile = testPKI.createKeystoreFile(baseDirectory, commonName, getKeystorePassword(), certificate);
+        keystoreFile = testPKI.createKeystoreFile(commonName, getKeystorePassword(), certificate);
         return keystoreFile;
     }
 
     /**
      * Get a reference to a PEM file containing the public certificate, creating
-     * a temporary file on disk if not already created.
-     *
-     * @return the certificate PEM file as a File object
-     */
-    public File getCertPemFile() {
-        return getCertPemFile(null);
-    }
-
-    /**
-     * Get a reference to a PEM file containing the public certificate, creating
-     * the file on disk in the specified directory if not already created.
+     * the file on disk if not already created.
      *
      * @return the certificate PEM file as a File object
      */
     @Synchronized
-    public File getCertPemFile(@Nullable File baseDirectory) {
+    public File getOrCreateCertPemFile() {
         if (certPemFile != null) {
             return certPemFile;
         }
-        certPemFile = TestPKI.createPemFile(baseDirectory, commonName, ".cert", Collections.singleton(certificate), c -> c.certificatePem().getBytes());
+        certPemFile = testPKI.createPemFile(commonName, ".cert", Collections.singleton(certificate), c -> c.certificatePem().getBytes());
         return certPemFile;
     }
 
@@ -116,26 +94,16 @@ public class TestPKICertificate {
 
     /**
      * Get a reference to a PEM file containing the unencrypted private key, creating
-     * a temporary file on disk if not already created.
-     *
-     * @return the key PEM file as a File object
-     */
-    public File getKeyPemFile() {
-        return getKeyPemFile(null);
-    }
-
-    /**
-     * Get a reference to a PEM file containing the unencrypted private key, creating
-     * the file on disk in the specified directory if not already created.
+     * the file on disk if not already created.
      *
      * @return the key PEM file as a File object
      */
     @Synchronized
-    public File getKeyPemFile(@Nullable File baseDirectory) {
+    public File getOrCreateKeyPemFile() {
         if (keyPemFile != null) {
             return keyPemFile;
         }
-        keyPemFile = TestPKI.createPemFile(baseDirectory, commonName, ".key", Collections.singleton(certificate), c -> c.privateKeyPkcs8Pem().getBytes());
+        keyPemFile = testPKI.createPemFile(commonName, ".key", Collections.singleton(certificate), c -> c.privateKeyPkcs8Pem().getBytes());
         return keyPemFile;
     }
 

--- a/src/test/java/com/dsingley/testpki/TestPKICertificateTest.java
+++ b/src/test/java/com/dsingley/testpki/TestPKICertificateTest.java
@@ -9,7 +9,7 @@ class TestPKICertificateTest {
 
     @Test
     void test() {
-        TestPKI testPKI = new TestPKI(KeyType.ECDSA_256);
+        TestPKI testPKI = new TestPKI(KeyType.ECDSA_256, null);
         TestPKICertificate certificate = testPKI.getOrCreateServerCertificate();
         assertAll(
                 () -> assertThat(certificate.getSubjectDN()).startsWith("CN=server"),

--- a/src/test/java/com/dsingley/testpki/TestPKITest.java
+++ b/src/test/java/com/dsingley/testpki/TestPKITest.java
@@ -1,5 +1,9 @@
 package com.dsingley.testpki;
 
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
 import lombok.NonNull;
 import mockwebserver3.MockResponse;
 import mockwebserver3.MockWebServer;
@@ -25,12 +29,8 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertAll;
-
 class TestPKITest {
-    private final TestPKI testPKI = new TestPKI(KeyType.RSA_2048);
+    private final TestPKI testPKI = new TestPKI(KeyType.RSA_2048, null);
 
     @Nested
     class API {
@@ -61,7 +61,7 @@ class TestPKITest {
         void testCustomServerCertificate() throws Exception {
             TestPKICertificate certificate = testPKI.getOrCreateServerCertificate("custom-server");
 
-            KeyStore keyStore = loadKeyStore(certificate.getKeystoreFile(), certificate.getKeystorePassword());
+            KeyStore keyStore = loadKeyStore(certificate.getOrCreateKeystoreFile(), certificate.getKeystorePassword());
             assertAll(
                     () -> assertThat(Collections.list(keyStore.aliases())).contains("custom-server"),
                     () -> assertThat(keyStore.isKeyEntry("custom-server")).isTrue()
@@ -76,7 +76,7 @@ class TestPKITest {
             Set<String> subjectAlternativeNames = new HashSet<>(Arrays.asList("san-1", "san-2"));
             TestPKICertificate testPKICertificate = testPKI.getOrCreateServerCertificate("san-server", subjectAlternativeNames);
 
-            KeyStore keyStore = loadKeyStore(testPKICertificate.getKeystoreFile(), testPKICertificate.getKeystorePassword());
+            KeyStore keyStore = loadKeyStore(testPKICertificate.getOrCreateKeystoreFile(), testPKICertificate.getKeystorePassword());
             assertAll(
                     () -> assertThat(Collections.list(keyStore.aliases())).contains("san-server"),
                     () -> assertThat(keyStore.isKeyEntry("san-server")).isTrue()
@@ -94,7 +94,7 @@ class TestPKITest {
         void testCustomClientCertificate() throws Exception {
             TestPKICertificate certificate = testPKI.getOrCreateClientCertificate("custom-client");
 
-            KeyStore keyStore = loadKeyStore(certificate.getKeystoreFile(), certificate.getKeystorePassword());
+            KeyStore keyStore = loadKeyStore(certificate.getOrCreateKeystoreFile(), certificate.getKeystorePassword());
             assertAll(
                     () -> assertThat(Collections.list(keyStore.aliases())).contains("custom-client"),
                     () -> assertThat(keyStore.isKeyEntry("custom-client")).isTrue()
@@ -192,7 +192,7 @@ class TestPKITest {
 
             @Test
             void testKeystoreFile() throws Exception {
-                File keystoreFile = testPKI.getOrCreateServerCertificate().getKeystoreFile();
+                File keystoreFile = testPKI.getOrCreateServerCertificate().getOrCreateKeystoreFile();
                 String keystorePassword = testPKI.getOrCreateServerCertificate().getKeystorePassword();
                 assertAll(
                         () -> assertThat(keystoreFile.getAbsolutePath()).matches(".*/server.*\\.pkcs12"),
@@ -215,7 +215,7 @@ class TestPKITest {
 
             @Test
             void testCertPemFile() throws Exception {
-                File certPemFile = testPKI.getOrCreateServerCertificate().getCertPemFile();
+                File certPemFile = testPKI.getOrCreateServerCertificate().getOrCreateCertPemFile();
                 assertAll(
                         () -> assertThat(certPemFile.getAbsolutePath()).matches(".*/server.*\\.cert"),
                         () -> assertThat(certPemFile).exists()
@@ -231,7 +231,7 @@ class TestPKITest {
 
             @Test
             void testKeyPemFile() throws Exception {
-                File keyPemFile = testPKI.getOrCreateServerCertificate().getKeyPemFile();
+                File keyPemFile = testPKI.getOrCreateServerCertificate().getOrCreateKeyPemFile();
                 assertAll(
                         () -> assertThat(keyPemFile.getAbsolutePath()).matches(".*/server.*\\.key"),
                         () -> assertThat(keyPemFile).exists()
@@ -251,7 +251,7 @@ class TestPKITest {
 
             @Test
             void testKeystoreFile() throws Exception {
-                File keystoreFile = testPKI.getOrCreateClientCertificate().getKeystoreFile();
+                File keystoreFile = testPKI.getOrCreateClientCertificate().getOrCreateKeystoreFile();
                 String keystorePassword = testPKI.getOrCreateClientCertificate().getKeystorePassword();
                 assertAll(
                         () -> assertThat(keystoreFile.getAbsolutePath()).matches(".*/client.*\\.pkcs12"),
@@ -271,7 +271,7 @@ class TestPKITest {
 
             @Test
             void testCertPemFile() throws Exception {
-                File certPemFile = testPKI.getOrCreateClientCertificate().getCertPemFile();
+                File certPemFile = testPKI.getOrCreateClientCertificate().getOrCreateCertPemFile();
                 assertAll(
                         () -> assertThat(certPemFile.getAbsolutePath()).matches(".*/client.*\\.cert"),
                         () -> assertThat(certPemFile).exists()
@@ -287,7 +287,7 @@ class TestPKITest {
 
             @Test
             void testKeyPemFile() throws Exception {
-                File keyPemFile = testPKI.getOrCreateClientCertificate().getKeyPemFile();
+                File keyPemFile = testPKI.getOrCreateClientCertificate().getOrCreateKeyPemFile();
                 assertAll(
                         () -> assertThat(keyPemFile.getAbsolutePath()).matches(".*/client.*\\.key"),
                         () -> assertThat(keyPemFile).exists()


### PR DESCRIPTION
TestPKI instances will now always create temporary files or files in the configured directory