### PR TITLE
Code cleanup

### DIFF
--- a/src/main/java/com/dsingley/testpki/TestPKI.java
+++ b/src/main/java/com/dsingley/testpki/TestPKI.java
@@ -274,7 +274,7 @@ public class TestPKI {
                 throw new RuntimeException("unexpected KeyType: " + keyType.name());
         }
         HeldCertificate certificate = builder.build();
-        log.info("issued certificate {}: {}", certificate.certificate().getSerialNumber(), certificate.certificate().getSubjectDN());
+        log.info("issued certificate {}: {}", certificate.certificate().getSerialNumber(), certificate.certificate().getSubjectX500Principal());
         return certificate;
     }
 
@@ -330,7 +330,7 @@ public class TestPKI {
                 } else {
                     fos.write("\n".getBytes());
                 }
-                fos.write(String.format("# %s%n", certificate.certificate().getSubjectDN().getName()).getBytes());
+                fos.write(String.format("# %s%n", certificate.certificate().getSubjectX500Principal().getName()).getBytes());
                 fos.write(function.apply(certificate));
             }
         }
@@ -352,7 +352,7 @@ public class TestPKI {
 
     @SneakyThrows
     private static String getCn(X509Certificate certificate) {
-        return new LdapName(certificate.getSubjectDN().getName()).getRdns().stream()
+        return new LdapName(certificate.getSubjectX500Principal().getName()).getRdns().stream()
                 .filter(rdn -> rdn.getType().equalsIgnoreCase("CN"))
                 .findFirst()
                 .orElseThrow(() -> new RuntimeException("no CN found"))

--- a/src/main/java/com/dsingley/testpki/TestPKICertificate.java
+++ b/src/main/java/com/dsingley/testpki/TestPKICertificate.java
@@ -46,7 +46,7 @@ public class TestPKICertificate {
      * @return the issuer DN as a string
      */
     public String getIssuerDN() {
-        return certificate.certificate().getIssuerDN().getName();
+        return certificate.certificate().getIssuerX500Principal().getName();
     }
 
     /**
@@ -55,7 +55,7 @@ public class TestPKICertificate {
      * @return the subject DN as a string
      */
     public String getSubjectDN() {
-        return certificate.certificate().getSubjectDN().getName();
+        return certificate.certificate().getSubjectX500Principal().getName();
     }
 
     /**

--- a/src/test/java/com/dsingley/testpki/TestPKITest.java
+++ b/src/test/java/com/dsingley/testpki/TestPKITest.java
@@ -93,7 +93,7 @@ class TestPKITest {
             );
 
             X509Certificate serverCertificate = getCertificate(keyStore, "custom-server");
-            assertThat(serverCertificate.getSubjectDN().getName()).startsWith("CN=custom-server");
+            assertThat(serverCertificate.getSubjectX500Principal().getName()).startsWith("CN=custom-server");
         }
 
         @Test
@@ -109,7 +109,7 @@ class TestPKITest {
 
             X509Certificate serverCertificate = getCertificate(keyStore, "san-server");
             assertAll(
-                    () -> assertThat(serverCertificate.getSubjectDN().getName()).startsWith("CN=san-server"),
+                    () -> assertThat(serverCertificate.getSubjectX500Principal().getName()).startsWith("CN=san-server"),
                     () -> assertThat(getSubjectAlternativeNames(serverCertificate)).contains("san-1"),
                     () -> assertThat(getSubjectAlternativeNames(serverCertificate)).contains("san-2")
             );
@@ -126,7 +126,7 @@ class TestPKITest {
             );
 
             X509Certificate serverCertificate = getCertificate(keyStore, "custom-client");
-            assertThat(serverCertificate.getSubjectDN().getName()).startsWith("CN=custom-client");
+            assertThat(serverCertificate.getSubjectX500Principal().getName()).startsWith("CN=custom-client");
         }
 
         @Test
@@ -201,10 +201,10 @@ class TestPKITest {
                 );
 
                 X509Certificate rootCertificate = getCertificate(keyStore, "root");
-                assertThat(rootCertificate.getSubjectDN().getName()).startsWith("CN=Root CA");
+                assertThat(rootCertificate.getSubjectX500Principal().getName()).startsWith("CN=Root CA");
 
                 X509Certificate intermediateCertificate = getCertificate(keyStore, "intermediate");
-                assertThat(intermediateCertificate.getSubjectDN().getName()).startsWith("CN=Intermediate CA");
+                assertThat(intermediateCertificate.getSubjectX500Principal().getName()).startsWith("CN=Intermediate CA");
             }
 
             @Test
@@ -246,7 +246,7 @@ class TestPKITest {
 
                 X509Certificate serverCertificate = getCertificate(keyStore, "server");
                 assertAll(
-                        () -> assertThat(serverCertificate.getSubjectDN().getName()).startsWith("CN=server"),
+                        () -> assertThat(serverCertificate.getSubjectX500Principal().getName()).startsWith("CN=server"),
                         () -> assertThat(getSubjectAlternativeNames(serverCertificate)).contains("localhost")
                 );
             }
@@ -304,7 +304,7 @@ class TestPKITest {
                 );
 
                 X509Certificate clientCertificate = getCertificate(keyStore, "client");
-                assertThat(clientCertificate.getSubjectDN().getName()).startsWith("CN=client");
+                assertThat(clientCertificate.getSubjectX500Principal().getName()).startsWith("CN=client");
             }
 
             @Test
@@ -364,7 +364,7 @@ class TestPKITest {
         @Override
         public List<InetAddress> lookup(@NonNull String hostname) throws UnknownHostException {
             return Dns.SYSTEM.lookup(hostname).stream()
-                    .filter(inetAddress -> inetAddress instanceof Inet4Address)
+                    .filter(Inet4Address.class::isInstance)
                     .collect(Collectors.toList());
         }
     }


### PR DESCRIPTION
* Replace deprecated API usage. The getSubjectDN and getIssuerDN are not deprecated until Java 16, but might as well not start using things that are deprecated in a future version.
* Replace usages of getSubjectDN with getSubjectX500Principal
* Replace usages of getIssuerDN with getIssuerX500Principal
* Replace lambda in TestPKITest.IPv4OnlyDns#lookup with method ref